### PR TITLE
Fix response to completed deprovision request

### DIFF
--- a/src/Server/Instances/ServiceInstancesController.cs
+++ b/src/Server/Instances/ServiceInstancesController.cs
@@ -136,13 +136,13 @@ namespace OpenServiceBroker.Instances
                 blocking: async x =>
                 {
                     await x.DeprovisionAsync(context, serviceId, planId);
-                    return Ok();
+                    return Ok(new {});
                 },
                 deferred: async x =>
                 {
                     var result = await x.DeprovisionAsync(context, serviceId, planId);
                     return result.Completed
-                        ? Ok()
+                        ? Ok(new {})
                         : AsyncResult(context, result);
                 });
         }


### PR DESCRIPTION
According to the [OSBAPI spec](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#response-9), the 200 OK response to a completed deprovision request should be `"{}"` instead of `""`.