### PR TITLE
Added unit tests for correct response to deprovision requests

### DIFF
--- a/src/Server/Instances/ServiceInstancesController.cs
+++ b/src/Server/Instances/ServiceInstancesController.cs
@@ -136,13 +136,13 @@ namespace OpenServiceBroker.Instances
                 blocking: async x =>
                 {
                     await x.DeprovisionAsync(context, serviceId, planId);
-                    return Ok();
+                    return Ok(new {});
                 },
                 deferred: async x =>
                 {
                     var result = await x.DeprovisionAsync(context, serviceId, planId);
                     return result.Completed
-                        ? Ok()
+                        ? Ok(new {})
                         : AsyncResult(context, result);
                 });
         }

--- a/src/UnitTests/Instances/ServiceInstanceBlockingFacts.cs
+++ b/src/UnitTests/Instances/ServiceInstanceBlockingFacts.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -92,6 +93,15 @@ namespace OpenServiceBroker.Instances
         {
             SetupMock(x => x.DeprovisionAsync(new ServiceInstanceContext("123"), "abc", "xyz"));
             await Client.ServiceInstancesBlocking["123"].DeprovisionAsync("abc", "xyz");
+        }
+
+        [Fact]
+        public async Task DeprovisionRequest()
+        {
+            var result = await Client.HttpClient.DeleteAsync(Client.ServiceInstancesBlocking["123"].Uri);
+            result.StatusCode.Should().BeEquivalentTo(HttpStatusCode.OK);
+            var resultString = await result.Content.ReadAsStringAsync();
+            resultString.Should().Be("{}");
         }
 
         [Fact]

--- a/src/UnitTests/Instances/ServiceInstanceDeferredFacts.cs
+++ b/src/UnitTests/Instances/ServiceInstanceDeferredFacts.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using System.Threading.Tasks;
 using FluentAssertions;
 using OpenServiceBroker.Errors;
@@ -146,6 +147,21 @@ namespace OpenServiceBroker.Instances
             SetupMock(x => x.DeprovisionAsync(new ServiceInstanceContext("123"), "abc", "xyz"), response);
             var result = await Client.ServiceInstancesDeferred["123"].DeprovisionAsync("abc", "xyz");
             result.Should().BeEquivalentTo(response);
+        }
+
+        [Fact]
+        public async Task DeprovisionCompletedRequest()
+        {
+            var response = new AsyncOperation
+            {
+                Completed = true
+            };
+
+            SetupMock(x => x.DeprovisionAsync(new ServiceInstanceContext("123"), null, null), response);
+            var result = await Client.HttpClient.DeleteAsync(Client.ServiceInstancesDeferred["123"].Uri);
+            result.StatusCode.Should().BeEquivalentTo(HttpStatusCode.OK);
+            var resultString = await result.Content.ReadAsStringAsync();
+            resultString.Should().Be("{}");
         }
 
         [Fact]


### PR DESCRIPTION
Added two unit tests that check whether the response to a completed deprovision request is 200 OK and contains `"{}"` (and not `""`).