### PR TITLE
Do not return volume_mounts when empty

### DIFF
--- a/src/Model/Bindings/ServiceBindingBase.cs
+++ b/src/Model/Bindings/ServiceBindingBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -30,6 +31,13 @@ namespace OpenServiceBroker.Bindings
         /// </summary>
         [JsonProperty("volume_mounts")]
         public List<ServiceBindingVolumeMount> VolumeMounts { get; } = new List<ServiceBindingVolumeMount>();
+
+        /// <summary>
+        /// Do not serialize volume mounts if there are none. On some platforms (PCF for example), binding credentials to
+        /// an application fails when an empty list of volume mounts is returned.
+        /// </summary>
+        /// <returns></returns>
+        public bool ShouldSerializeVolumeMounts() => VolumeMounts.Any();
 
         protected bool Equals(ServiceBindingBase other)
             => SyslogDrainUrl == other.SyslogDrainUrl

--- a/src/Model/Bindings/ServiceBindingBase.cs
+++ b/src/Model/Bindings/ServiceBindingBase.cs
@@ -11,19 +11,19 @@ namespace OpenServiceBroker.Bindings
         /// <summary>
         /// A free-form hash of credentials that can be used by applications or users to access the service. MUST be returned if the Service Broker supports generation of credentials.
         /// </summary>
-        [JsonProperty("credentials")]
+        [JsonProperty("credentials", NullValueHandling = NullValueHandling.Ignore)]
         public JObject Credentials { get; set; }
 
         /// <summary>
         /// A URL to which logs MUST be streamed. <see cref="Catalogs.Service.Requires"/>: <see cref="Catalogs.Features.SyslogDrain"/> MUST be declared in the Catalog endpoint or the Platform can consider the response invalid.
         /// </summary>
-        [JsonProperty("syslog_drain_url")]
+        [JsonProperty("syslog_drain_url", NullValueHandling = NullValueHandling.Ignore)]
         public Uri SyslogDrainUrl { get; set; }
 
         /// <summary>
         /// A URL to which the Platform MUST proxy requests for the address sent with <see cref="ServiceBindingResourceObject.Route"/> in the request body. <see cref="Catalogs.Service.Requires"/>: <see cref="Catalogs.Features.RouteForwarding"/> MUST be declared in the Catalog endpoint or the Platform can consider the response invalid.
         /// </summary>
-        [JsonProperty("route_service_url")]
+        [JsonProperty("route_service_url", NullValueHandling = NullValueHandling.Ignore)]
         public Uri RouteServiceUrl { get; set; }
 
         /// <summary>

--- a/src/Server/Instances/ServiceInstancesController.cs
+++ b/src/Server/Instances/ServiceInstancesController.cs
@@ -136,13 +136,13 @@ namespace OpenServiceBroker.Instances
                 blocking: async x =>
                 {
                     await x.DeprovisionAsync(context, serviceId, planId);
-                    return Ok(new {});
+                    return Ok();
                 },
                 deferred: async x =>
                 {
                     var result = await x.DeprovisionAsync(context, serviceId, planId);
                     return result.Completed
-                        ? Ok(new {})
+                        ? Ok()
                         : AsyncResult(context, result);
                 });
         }

--- a/src/Server/Instances/ServiceInstancesController.cs
+++ b/src/Server/Instances/ServiceInstancesController.cs
@@ -136,13 +136,13 @@ namespace OpenServiceBroker.Instances
                 blocking: async x =>
                 {
                     await x.DeprovisionAsync(context, serviceId, planId);
-                    return Ok();
+                    return Ok(new {});
                 },
                 deferred: async x =>
                 {
                     var result = await x.DeprovisionAsync(context, serviceId, planId);
                     return result.Completed
-                        ? Ok()
+                        ? Ok(new {})
                         : AsyncResult(context, result);
                 });
         }


### PR DESCRIPTION
When binding credentials to an application on Pivotal Cloud Foundry (PCF), the library returns an empty list of `volume_mounts`. PCF doesn't like this and returns an error:

    The service broker returned an invalid response for the request to
    https://rwwilden-broker.cfapps.io/v2/service_instances/cb73e22b-b5fd-40cc-8e4d-bedc9482fea8/service_bindings/73d6cf20-8adb-47dd-be60-50656f8e1801?accepts_incomplete=true:
    The service is attempting to supply volume mounts from your application, but is not
    registered as a volume mount service. Please contact the service provider.

Additionally, I added the `NullValueHandling` property to `Credentials`, `SyslogDrainUrl` and `RouteServiceUrl` to ensure these are not serialized when not set.