### PR TITLE
Required fields from model do not match OSBAPI spec

### DIFF
--- a/src/Model/Instances/ServiceInstanceBase.cs
+++ b/src/Model/Instances/ServiceInstanceBase.cs
@@ -11,11 +11,7 @@ namespace OpenServiceBroker.Instances
         [JsonProperty("service_id", Required = Required.Always)]
         public string ServiceId { get; set; }
 
-        /// <summary>
-        /// MUST be the ID of a <see cref="Catalogs.Plan"/> from the service that has been requested.
-        /// </summary>
-        [JsonProperty("plan_id", Required = Required.Always)]
-        public string PlanId { get; set; }
+        public abstract string PlanId { get; set; }
 
         /// <summary>
         /// Configuration parameters for the Service Instance. Service Brokers SHOULD ensure that the client has provided valid configuration parameters and values for the operation.

--- a/src/Model/Instances/ServiceInstanceProvisionRequest.cs
+++ b/src/Model/Instances/ServiceInstanceProvisionRequest.cs
@@ -7,6 +7,12 @@ namespace OpenServiceBroker.Instances
     public class ServiceInstanceProvisionRequest : ServiceInstanceBase, IEquatable<ServiceInstanceProvisionRequest>
     {
         /// <summary>
+        /// MUST be the ID of a <see cref="Catalogs.Plan"/> from the service that has been requested.
+        /// </summary>
+        [JsonProperty("plan_id", Required = Required.Always)]
+        public override string PlanId { get; set; }
+
+        /// <summary>
         /// Platform specific contextual information under which the Service Instance is to be provisioned. Although most Service Brokers will not use this field, it could be helpful in determining data placement or applying custom business rules.
         /// </summary>
         /// <remarks>This will replace <see cref="OrganizationGuid"/> and <see cref="SpaceGuid"/> in future versions of the specification - in the interim both SHOULD be used to ensure interoperability with old and new implementations.</remarks>
@@ -16,14 +22,14 @@ namespace OpenServiceBroker.Instances
         /// <summary>
         /// Deprecated in favor of <see cref="Context"/>. The Platform GUID for the organization under which the Service Instance is to be provisioned. Although most Service Brokers will not use this field, it might be helpful for executing operations on a user's behalf. MUST be a non-empty string.
         /// </summary>
-        [JsonProperty("organization_guid")]
+        [JsonProperty("organization_guid", Required = Required.Always)]
         //[Obsolete("Deprecated in favor of " + nameof(Context))]
         public string OrganizationGuid { get; set; }
 
         /// <summary>
         /// Deprecated in favor of <see cref="Context"/>. The identifier for the project space within the Platform organization. Although most Service Brokers will not use this field, it might be helpful for executing operations on a user's behalf. MUST be a non-empty string.
         /// </summary>
-        [JsonProperty("space_guid")]
+        [JsonProperty("space_guid", Required = Required.Always)]
         //[Obsolete("Deprecated in favor of " + nameof(Context))]
         public string SpaceGuid { get; set; }
 

--- a/src/Model/Instances/ServiceInstanceResource.cs
+++ b/src/Model/Instances/ServiceInstanceResource.cs
@@ -6,6 +6,12 @@ namespace OpenServiceBroker.Instances
     public class ServiceInstanceResource : ServiceInstanceBase, IEquatable<ServiceInstanceResource>
     {
         /// <summary>
+        /// The ID of the <see cref="Catalogs.Plan"/> from the catalog that is associated with the Service Instance.
+        /// </summary>
+        [JsonProperty("plan_id")]
+        public override string PlanId { get; set; }
+
+        /// <summary>
         /// The URL of a web-based management user interface for the Service Instance; we refer to this as a service dashboard. The URL MUST contain enough information for the dashboard to identify the resource being accessed.
         /// </summary>
         [JsonProperty("dashboard_url")]

--- a/src/Model/Instances/ServiceInstanceUpdateRequest.cs
+++ b/src/Model/Instances/ServiceInstanceUpdateRequest.cs
@@ -1,10 +1,23 @@
 using System;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace OpenServiceBroker.Instances
 {
-    public class ServiceInstanceUpdateRequest : ServiceInstanceProvisionRequest, IEquatable<ServiceInstanceUpdateRequest>
+    public class ServiceInstanceUpdateRequest : ServiceInstanceBase, IEquatable<ServiceInstanceUpdateRequest>
     {
+        /// <summary>
+        /// Contextual data under which the Service Instance is created.
+        /// </summary>
+        [JsonProperty("context")]
+        public JObject Context { get; set; }
+
+        /// <summary>
+        /// If present, MUST be the ID of a <see cref="Catalogs.Plan"/> from the service that has been requested. If this field is not present in the request message, then the Service Broker MUST NOT change the plan of the instance as a result of this request.
+        /// </summary>
+        [JsonProperty("plan_id")]
+        public override string PlanId { get; set; }
+
         /// <summary>
         /// Information about the Service Instance prior to the update.
         /// </summary>

--- a/src/Server/Instances/ServiceInstancesController.cs
+++ b/src/Server/Instances/ServiceInstancesController.cs
@@ -136,13 +136,13 @@ namespace OpenServiceBroker.Instances
                 blocking: async x =>
                 {
                     await x.DeprovisionAsync(context, serviceId, planId);
-                    return Ok(new {});
+                    return Ok();
                 },
                 deferred: async x =>
                 {
                     var result = await x.DeprovisionAsync(context, serviceId, planId);
                     return result.Completed
-                        ? Ok(new {})
+                        ? Ok()
                         : AsyncResult(context, result);
                 });
         }

--- a/src/Server/Instances/ServiceInstancesController.cs
+++ b/src/Server/Instances/ServiceInstancesController.cs
@@ -136,13 +136,13 @@ namespace OpenServiceBroker.Instances
                 blocking: async x =>
                 {
                     await x.DeprovisionAsync(context, serviceId, planId);
-                    return Ok();
+                    return Ok(new {});
                 },
                 deferred: async x =>
                 {
                     var result = await x.DeprovisionAsync(context, serviceId, planId);
                     return result.Completed
-                        ? Ok()
+                        ? Ok(new {})
                         : AsyncResult(context, result);
                 });
         }

--- a/src/UnitTests/Instances/HeaderFacts.cs
+++ b/src/UnitTests/Instances/HeaderFacts.cs
@@ -28,7 +28,9 @@ namespace OpenServiceBroker.Instances
             var request = new ServiceInstanceProvisionRequest
             {
                 ServiceId = "abc",
-                PlanId = "xyz"
+                PlanId = "xyz",
+                OrganizationGuid = "org",
+                SpaceGuid = "space"
             };
             var identity = new OriginatingIdentity("myplatform", new JObject {{"id", "test"}});
 

--- a/src/UnitTests/Instances/ServiceInstanceBlockingFacts.cs
+++ b/src/UnitTests/Instances/ServiceInstanceBlockingFacts.cs
@@ -30,7 +30,9 @@ namespace OpenServiceBroker.Instances
             var request = new ServiceInstanceProvisionRequest
             {
                 ServiceId = "abc",
-                PlanId = "xyz"
+                PlanId = "xyz",
+                OrganizationGuid = "org",
+                SpaceGuid = "space"
             };
             var response = new ServiceInstanceProvision
             {
@@ -48,7 +50,9 @@ namespace OpenServiceBroker.Instances
             var request = new ServiceInstanceProvisionRequest
             {
                 ServiceId = "abc",
-                PlanId = "xyz"
+                PlanId = "xyz",
+                OrganizationGuid = "org",
+                SpaceGuid = "space"
             };
             var response = new ServiceInstanceProvision
             {
@@ -67,7 +71,9 @@ namespace OpenServiceBroker.Instances
             var request = new ServiceInstanceProvisionRequest
             {
                 ServiceId = "abc",
-                PlanId = "xyz"
+                PlanId = "xyz",
+                OrganizationGuid = "org",
+                SpaceGuid = "space"
             };
 
             SetupMock(x => x.ProvisionAsync(new ServiceInstanceContext("123"), request), new ConflictException("custom message"));

--- a/src/UnitTests/Instances/ServiceInstanceDeferredFacts.cs
+++ b/src/UnitTests/Instances/ServiceInstanceDeferredFacts.cs
@@ -28,7 +28,9 @@ namespace OpenServiceBroker.Instances
             var request = new ServiceInstanceProvisionRequest
             {
                 ServiceId = "abc",
-                PlanId = "xyz"
+                PlanId = "xyz",
+                OrganizationGuid = "org",
+                SpaceGuid = "space"
             };
             var response = new ServiceInstanceAsyncOperation
             {
@@ -47,7 +49,9 @@ namespace OpenServiceBroker.Instances
             var request = new ServiceInstanceProvisionRequest
             {
                 ServiceId = "abc",
-                PlanId = "xyz"
+                PlanId = "xyz",
+                OrganizationGuid = "org",
+                SpaceGuid = "space"
             };
             var response = new ServiceInstanceAsyncOperation().Complete(new ServiceInstanceProvision
             {
@@ -65,7 +69,9 @@ namespace OpenServiceBroker.Instances
             var request = new ServiceInstanceProvisionRequest
             {
                 ServiceId = "abc",
-                PlanId = "xyz"
+                PlanId = "xyz",
+                OrganizationGuid = "org",
+                SpaceGuid = "space"
             };
             var response = new ServiceInstanceAsyncOperation().Complete(new ServiceInstanceProvision
             {
@@ -84,7 +90,9 @@ namespace OpenServiceBroker.Instances
             var request = new ServiceInstanceProvisionRequest
             {
                 ServiceId = "abc",
-                PlanId = "xyz"
+                PlanId = "xyz",
+                OrganizationGuid = "org",
+                SpaceGuid = "space"
             };
 
             SetupMock(x => x.ProvisionAsync(new ServiceInstanceContext("123"), request), new ConflictException("custom message"));

--- a/src/UnitTests/Instances/ServiceInstancePollingFacts.cs
+++ b/src/UnitTests/Instances/ServiceInstancePollingFacts.cs
@@ -14,7 +14,9 @@ namespace OpenServiceBroker.Instances
             var request = new ServiceInstanceProvisionRequest
             {
                 ServiceId = "abc",
-                PlanId = "xyz"
+                PlanId = "xyz",
+                OrganizationGuid = "org",
+                SpaceGuid = "space"
             };
             var response = new ServiceInstanceAsyncOperation
             {
@@ -43,7 +45,9 @@ namespace OpenServiceBroker.Instances
             var request = new ServiceInstanceProvisionRequest
             {
                 ServiceId = "abc",
-                PlanId = "xyz"
+                PlanId = "xyz",
+                OrganizationGuid = "org",
+                SpaceGuid = "space"
             };
             var syntheticResponse = new ServiceInstanceProvision
             {
@@ -62,7 +66,9 @@ namespace OpenServiceBroker.Instances
             var request = new ServiceInstanceProvisionRequest
             {
                 ServiceId = "abc",
-                PlanId = "xyz"
+                PlanId = "xyz",
+                OrganizationGuid = "org",
+                SpaceGuid = "space"
             };
 
             SetupMock(x => x.ProvisionAsync(new ServiceInstanceContext("123"), request), new ConflictException("custom message"));
@@ -75,7 +81,9 @@ namespace OpenServiceBroker.Instances
             var request = new ServiceInstanceProvisionRequest
             {
                 ServiceId = "abc",
-                PlanId = "xyz"
+                PlanId = "xyz",
+                OrganizationGuid = "org",
+                SpaceGuid = "space"
             };
             var response = new ServiceInstanceAsyncOperation
             {


### PR DESCRIPTION
Fixes issue #7 by reorganizing some properties between classes and base classes:

- In `ServiceInstanceProvisionRequest`, both `organization_guid` and `space_guid` are now required
- Made `plan_id` an abstract property in `ServiceInstanceBase` so sub classes can specify for themselves whether `plan_id` is required
- `ServiceInstanceUpdateRequest` no longer extends from `ServiceInstanceProvisionRequest` but from `ServiceInstanceBase` to prevent `plan_id` from being required